### PR TITLE
Remove unused Ionicons imports

### DIFF
--- a/app/Discovery.tsx
+++ b/app/Discovery.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Ionicons } from '@expo/vector-icons';
 
 type Profile = {
   id: string;

--- a/app/Matches.tsx
+++ b/app/Matches.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Ionicons } from '@expo/vector-icons';
 
 type Profile = {
   id: string;


### PR DESCRIPTION
## Summary
- clean up unused imports

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685655ea52a08328b51af05065fdc0e8