### PR TITLE
Remove unused import from admin screen

### DIFF
--- a/app/admin.tsx
+++ b/app/admin.tsx
@@ -8,7 +8,6 @@ import {
   Alert,
 } from 'react-native';
 import { PlusCircle, Trash2, Pencil, Download } from 'lucide-react-native';
-import { useLocalSearchParams } from 'expo-router';
 import { Event } from '@/api/entities';
 import Toast from 'react-native-toast-message';
 import EventFormModal from '@/components/admin/EventFormModal';


### PR DESCRIPTION
## Summary
- clean up admin screen by removing unused `useLocalSearchParams` import

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685655ebe6888328bad72a9cd703e2e3