### PR TITLE
Improve state typings

### DIFF
--- a/app/Consent.tsx
+++ b/app/Consent.tsx
@@ -10,6 +10,7 @@ import Toast from 'react-native-toast-message';
 
 import { UploadFile } from '@/api/integrations';
 import { Event, EventProfile, User } from '../api/entities';
+import { EventData, EventProfileData, UserData } from '@/types';
 
 const COLORS = [
   "#ff6b6b", "#4ecdc4", "#45b7d1", "#96ceb4", "#feca57",
@@ -18,11 +19,11 @@ const COLORS = [
 
 export default function ConsentScreen() {
   const router = useRouter();
-  const [currentEvent, setCurrentEvent] = useState<any>(null);
+  const [currentEvent, setCurrentEvent] = useState<EventData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [profilePhotoPreview, setProfilePhotoPreview] = useState<string | null>(null);
-  const [profilePhoto, setProfilePhoto] = useState<any>(null);
+  const [profilePhoto, setProfilePhoto] = useState<ImagePicker.ImagePickerAsset | null>(null);
   const [formData, setFormData] = useState({
     first_name: '',
     age: '',

--- a/app/LayoutScreen.tsx
+++ b/app/LayoutScreen.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
 import { Like, Event, EventProfile, Message } from '@/api/entities';
+import { EventData } from '@/types';
 import MatchNotificationToast from '@/components/MatchNotificationToast';
 import MessageNotificationToast from '@/components/MessageNotificationToast';
 import FeedbackSurveyModal from '@/components/FeedbackSurveyModal';
@@ -18,7 +19,7 @@ export default function LayoutScreen() {
   const [showMessageToast, setShowMessageToast] = useState(false);
   const [newMessageDetails, setNewMessageDetails] = useState({ name: '' });
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
-  const [feedbackEvent, setFeedbackEvent] = useState<any>(null);
+  const [feedbackEvent, setFeedbackEvent] = useState<EventData | null>(null);
   const [feedbackSessionId, setFeedbackSessionId] = useState<string | null>(null);
 
   const checkFeedbackEligibility = useCallback(async () => {

--- a/app/Profile.tsx
+++ b/app/Profile.tsx
@@ -17,6 +17,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // ✅ Add these imports for backend helpers
 import { User, EventProfile } from '@/api/entities';
+import { UserData, EventProfileData } from '@/types';
 import { UploadFile } from '@/api/integrations'; // ✅ Correct
 
 
@@ -30,8 +31,8 @@ const ALL_INTERESTS = [
 
 export default function ProfileScreen() {
   const router = useRouter();
-  const [user, setUser] = useState<any>(null);
-  const [eventProfile, setEventProfile] = useState<any>(null);
+  const [user, setUser] = useState<UserData | null>(null);
+  const [eventProfile, setEventProfile] = useState<EventProfileData | null>(null);
   const [formData, setFormData] = useState({ bio: '', interests: [], height: '' });
   const [isLoading, setIsLoading] = useState(true);
   const [isUploading, setIsUploading] = useState(false);

--- a/app/admin.tsx
+++ b/app/admin.tsx
@@ -10,12 +10,13 @@ import {
 import { PlusCircle, Trash2, Pencil, Download } from 'lucide-react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { Event } from '@/api/entities';
+import { EventData } from '@/types';
 import Toast from 'react-native-toast-message';
 import EventFormModal from '@/components/admin/EventFormModal';
 
 export default function AdminScreen() {
-  const [events, setEvents] = useState<any[]>([]);
-  const [selectedEvent, setSelectedEvent] = useState<any | null>(null);
+  const [events, setEvents] = useState<EventData[]>([]);
+  const [selectedEvent, setSelectedEvent] = useState<EventData | null>(null);
   const [showFormModal, setShowFormModal] = useState(false);
 
   const fetchEvents = useCallback(async () => {

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,36 @@
+export interface UserData {
+  id?: string;
+  full_name?: string;
+  bio?: string;
+  interests?: string[];
+  height?: string;
+  profile_color?: string;
+  profile_photo_url?: string;
+  age?: number;
+  gender_identity?: string;
+  interested_in?: string;
+}
+
+export interface EventProfileData {
+  id?: string;
+  event_id?: string;
+  session_id?: string;
+  profile_photo_url?: string;
+  first_name?: string;
+  age?: number;
+  gender_identity?: string;
+  interested_in?: string;
+  profile_color?: string;
+  bio?: string;
+}
+
+export interface EventData {
+  id: string;
+  name?: string;
+  code?: string;
+  location?: string;
+  description?: string;
+  organizer_email?: string;
+  starts_at?: string;
+  expires_at?: string;
+}


### PR DESCRIPTION
## Summary
- define interfaces for user, event, and event profile objects
- use these interfaces in Profile, LayoutScreen, Admin, and Consent screens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685655ef7b108328aec628576ea6ee42