### PR TITLE
Fix web entry to use createRoot

### DIFF
--- a/index.web.tsx
+++ b/index.web.tsx
@@ -1,10 +1,10 @@
 // index.web.tsx
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import AdminApp from './components/admin/AdminApp';
 
-const root = document.getElementById('root');
+const rootEl = document.getElementById('root');
 
-if (root) {
-  ReactDOM.render(<AdminApp />, root);
+if (rootEl) {
+  createRoot(rootEl).render(<AdminApp />);
 }


### PR DESCRIPTION
## Summary
- modernize web entry point
- swap deprecated `ReactDOM.render` for `createRoot`

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_685655f2c234832893beb575338fda7f