### PR TITLE
Use config for Expo project ID

### DIFF
--- a/constants/AppConfig.ts
+++ b/constants/AppConfig.ts
@@ -1,0 +1,1 @@
+export const EXPO_PROJECT_ID = process.env.EXPO_PUBLIC_PROJECT_ID ?? '';

--- a/notificationsStore.ts
+++ b/notificationsStore.ts
@@ -2,6 +2,7 @@ import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { useRouter } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
+import { EXPO_PROJECT_ID } from '@/constants/AppConfig';
 
 // Configure notification behavior
 Notifications.setNotificationHandler({
@@ -77,7 +78,7 @@ async function registerForPushNotificationsAsync(): Promise<Notifications.ExpoPu
     }
 
     token = await Notifications.getExpoPushTokenAsync({
-      projectId: 'your-expo-project-id-here',
+      projectId: EXPO_PROJECT_ID,
     });
 
     return token;


### PR DESCRIPTION
## Summary
- centralize Expo project ID in new `AppConfig` constant
- use that constant when registering notifications

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685655f1c9f883289f502cc15ab2ab9c